### PR TITLE
ci: move long tests to 5:21 UTC

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -1,12 +1,12 @@
 name: HW Soak
 
-# Run long tests once nightly, at 00:00
+# Run long tests once daily, at 05:21 UTC
 on:
   pull_request:
     types:
       - labeled
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "21 5 * * *"
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
Long tests were set to run at midnight UTC, which is 7 pm EST and might be using CI resources at an inconvenient time. Move this closer to midnight EST.

This PR is just a test to see if gitlab CI runs on forks